### PR TITLE
Added recent jams to News page and fixed info issues on Home page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <div class="body_text">
         <div class="header_content">
             <h1 class="header_padding">Welcome to the UNL Game Development Club</h1>
-            <p>We are UNL's only club focused on learning to develop video games. All are welcome and there are no pre-requisites to join. We usually meet in <a href="https://maps.unl.edu/AVH" target="_blank">Avery Hall</a> <a href="https://cse.unl.edu/map-avery-hall-basement" target="_blank">19</a> on Sunday nights from 7pm-9pm. Visit the <a href="contact.html">contact page</a> to sign up for updates.</p>
+            <p>We are UNL's only club focused on learning to develop video games. All are welcome and there are no pre-requisites to join. Visit the <a href="contact.html">contact page</a> to get in touch with us or to join the Discord community.</p>
             <p><b>Our mission: To guide students in learning effective professional game design techniques.</b> We accomplish this by working through game development projects in our meetings, such as demos or active projects. We also provide students the opportunity to showcase their skills at game development competitions ("game jams").</p>
 
             <p>To get involved, please visit the <a href="contact.html">contact page</a> and reach out to one of the club officers.</p>

--- a/news.html
+++ b/news.html
@@ -34,6 +34,21 @@
         <div id="competition_news">
             <h1>Competitions</h1>
             <div class="news_content">
+                <h2>Game Maker's Toolkit Game Jam 2020</h2>
+                <h3>July 10<sup>th</sup> - 12<sup>th</sup>, 2020</h3>
+                <p>A few club members participated in a team in the online <a href="https://itch.io/jam/gmtk-2020">Game Maker's Toolkit (GMTK) Game Jam 2020</a> on July 10<sup>th</sup> - 12<sup>th</sup>. This jam was the largest online jam of all time at the time. The theme was "Out of Control". The students in the team were Jaden Goter, Camden Obertop, Zach Randolph, Erik Skoog, and Matt Lowe. All students but Zach were juniors in Software Engineering. Zach was a junior in Computer Science. The team made the game <a href="https://camdeno.itch.io/whiz-blade">Whiz Blade</a>, which placed within the top 2% of games in the jam. The other submissions can be played on the jam's <a href="https://itch.io/jam/gmtk-2019/entries">itch.io submission page</a>. The winners from the jam are showcased in the <a href="https://www.youtube.com/watch?v=RGeAkU2wu4o">wrap-up video</a>.</p>
+            </div>
+            <div class="news_content">
+                <h2>Ludum Dare 46</h2>
+                <h3>April 17<sup>th</sup> - 20<sup>th</sup>, 2020</h3>
+                <p>A few club members participated in a team in the online <a href="https://ldjam.com/events/ludum-dare/46/">Ludum Dare 46 Game Jam</a> on April 17<sup>th</sup> - 20<sup>th</sup>. This jam was the largest online jam of all time at the time. The theme was "Keep It Alive". The students in the team were Jaden Goter, Camden Obertop, Grant Davis, Erik Skoog, and Matt Lowe. All students were sophomores in Software Engineering. The team made the game <a href="https://grantimation.itch.io/squatch-watch">Squatch Watch</a>, which placed within the top 25% of games in the jam. The other submissions can be played on the jam's <a href="https://ldjam.com/events/ludum-dare/46/games">LD submission page</a>.</p>
+            </div>
+            <div class="news_content">
+                <h2>Kansas State University Game Jam 2020</h2>
+                <h3>February 14<sup>th</sup> - 16<sup>th</sup>, 2020</h3>
+                <p>The UNL Game Development Club competed in Kansas State University’s sixth annual Game Jam competition. The goal of the competition was to develop a video game (in teams of up to 4) based on a given theme in 48 hours. This year’s theme was "What Goes Up Must Come Down". All four games can be found on the <a href="https://itch.io/jam/ksu-game-jam-2020" target="_blank">K-State Game Jam's itch.io page</a>.</p>
+            </div>
+            <div class="news_content">
                 <h2>UNL Philosophy Game Jam 2019</h2>
                 <h3>October 16<sup>th</sup> - October 31<sup>st</sup>, 2019</h3>
                 <p>The club competed in the 2019 UNL Philosophy Game Jam. The students who attended were Casey Lafferty and Molly Lee. The team made the game "So Sally" based on this year's Ethics and Technology theme.</p>
@@ -44,6 +59,11 @@
                 <h3>October 4<sup>th</sup> - 6<sup>th</sup>, 2019</h3>
                 <p>The club competed in the 2019 Chillennium Game Jam. The students who attended were Casey Lafferty, Molly Lee, and Ian Meister. The team made the game "The Three Mutineers" based on this year's theme, "One For All And All For One".</p>
                 <p>The project can be viewed and played on the club's <a href="https://github.com/UNL-Game-Dev-Club/The-Three-Mutineers" target="_blank">GitHub repository</a>.</p>
+            </div>
+            <div class="news_content">
+                <h2>Game Maker's Toolkit Game Jam 2019</h2>
+                <h3>August 2<sup>nd</sup> - 4<sup>th</sup>, 2019</h3>
+                <p>A few club members participated in the online <a href="https://itch.io/jam/gmtk-2019">Game Maker's Toolkit (GMTK) Game Jam 2019</a> on August 2<sup>nd</sup> - 4<sup>th</sup>. This jam was the largest online jam of all time at the time. The theme was "Only One". The games can be played on the jam's <a href="https://itch.io/jam/gmtk-2019/entries">itch.io submission page</a>, and the club's submissions can be found on the <a href="https://unl-game-dev-club.github.io/projects.html">Projects page</a>. The winners from the jam are showcased in the <a href="https://www.youtube.com/watch?v=o-WrQ77zUvA">wrap-up video</a>.</p>
             </div>
             <div class="news_content">
                 <h2>Kansas State University Game Jam 2019</h2>


### PR DESCRIPTION
The recent K-State, GMTK, and LD 46 game jams were added to the news page, as well as the 2019 GMTK game jam that we missed including.

A blurb about meeting in person was also removed from the Home page to reflect the recently announced online nature of the club for the fall semester.